### PR TITLE
Some fixes

### DIFF
--- a/src/LiteDB/Engine/Query/Optimization/QueryOptimization.cs
+++ b/src/LiteDB/Engine/Query/Optimization/QueryOptimization.cs
@@ -84,7 +84,7 @@ internal class QueryOptimization : IQueryOptimization
                 throw ERR($"Invalid WHERE expression: {predicate}");
             }
         }
-        else
+        else if (predicate is not EmptyBsonExpression)
         {
             throw ERR($"Invalid WHERE expression: {predicate}");
         }

--- a/src/LiteDB/Engine/Services/AllocationMap/AllocationMapService.cs
+++ b/src/LiteDB/Engine/Services/AllocationMap/AllocationMapService.cs
@@ -68,9 +68,11 @@ internal class AllocationMapService : IAllocationMapService
     }
 
     /// <summary>
-    /// Get a free PageID based on colID/type/length. Create extend or new am page if needed. Return isNew if page are empty (must be initialized)
+    /// Get a free PageID and ExtendID based on colID/type/length. 
+    /// Create extend or new am page if needed. 
+    /// Return isNew if page are empty (must be initialized)
     /// </summary>
-    public (int pageID, bool isNew) GetFreeExtend(byte colID, PageType type, int length)
+    public (int pageID, int extendIndex, bool isNew) GetFreeExtend(byte colID, PageType type, int length)
     {
         foreach(var page in _pages)
         {
@@ -78,17 +80,16 @@ internal class AllocationMapService : IAllocationMapService
 
             if (extendIndex != -1)
             {
-                var pageID = 0; // sombrio (pageIndex)
-
-                return (pageID, isNew);
+                return (page.GetBlockPageID(extendIndex, pageIndex), extendIndex, isNew);
             }
         }
 
         var extendLocation = this.CreateNewExtend(colID);
+        var amPage = _pages[extendLocation.AllocationMapID];
 
-        var firstPageID = extendLocation.FirstPageID;
+        var firstPageID = amPage.GetBlockPageID(extendLocation.ExtendID, 0);
 
-        return (firstPageID, true);
+        return (firstPageID, extendLocation.ExtendIndex, true);
     }
 
     /// <summary>

--- a/src/LiteDB/Engine/Services/AllocationMap/ExtendLocation.cs
+++ b/src/LiteDB/Engine/Services/AllocationMap/ExtendLocation.cs
@@ -1,6 +1,6 @@
 ﻿namespace LiteDB.Engine;
 
-internal struct ExtendLocation
+internal readonly struct ExtendLocation
 {
     public static ExtendLocation Empty = new(-1, -1);
     public static ExtendLocation First = new(0, 0);
@@ -8,13 +8,12 @@ internal struct ExtendLocation
     public readonly int AllocationMapID;
     public readonly int ExtendIndex;
 
-    public int ExtendID => this.IsEmpty ? -1 : (this.AllocationMapID * AM_EXTEND_COUNT) + this.ExtendIndex;
-
-    public int FirstPageID => 0; //sombrio
+    public readonly int ExtendID => this.IsEmpty ? -1 : (this.AllocationMapID * AM_EXTEND_COUNT) + this.ExtendIndex;
 
     public ExtendLocation(int extendID)
     {
-        //sombrio
+        this.AllocationMapID = extendID / AM_EXTEND_COUNT;
+        this.ExtendIndex = extendID % AM_EXTEND_COUNT;
     }
 
     public ExtendLocation(int allocationMapID, int extendIndex)
@@ -23,11 +22,11 @@ internal struct ExtendLocation
         this.ExtendIndex = extendIndex;
     }
 
-    public bool IsEmpty => 
+    public readonly bool IsEmpty => 
         this.AllocationMapID == Empty.AllocationMapID && 
         this.ExtendIndex == Empty.ExtendIndex;
 
-    public ExtendLocation Next()
+    public readonly ExtendLocation Next()
     {
         var allocationMapID = this.AllocationMapID;
         var extendIndex = this.ExtendIndex + 1;
@@ -41,7 +40,7 @@ internal struct ExtendLocation
         return new ExtendLocation(allocationMapID, extendIndex);
     }
 
-    public override string ToString()
+    public override readonly string ToString()
     {
         return $"AMP: {this.AllocationMapID}, ExtIndex: {this.ExtendIndex}, ExtendID: {this.ExtendID}";
     }

--- a/src/LiteDB/Engine/Services/Data/DataService.cs
+++ b/src/LiteDB/Engine/Services/Data/DataService.cs
@@ -120,6 +120,8 @@ internal class DataService : IDataService
 
         // get current datablock (for first one)
         var page = await _transaction.GetPageAsync(rowID.PageID, true);
+        // HACK: all dirty pages must not have PositionID
+        page.PositionID = int.MaxValue;
         //var dataBlock = new DataBlock(page, rowID);
 
         // TODO: tá implementado só pra 1 pagina


### PR DESCRIPTION
Hi, I have made a few fixes on:
- Some extendID calculations are missing
- In SplitWhereInTerms, WHERE clause can be empty if there is not WHERE 
Also, I force page.PositionID in UpdateDocumentAsync to be int.MaxValue because all dirty pages's PositionID must be int.MaxValue. Not sure if I am doing the right thing.